### PR TITLE
Add caching and configurable thumbnail quality

### DIFF
--- a/custom_components/immich/__init__.py
+++ b/custom_components/immich/__init__.py
@@ -16,7 +16,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})
 
-    hub = ImmichHub(host=entry.data[CONF_HOST], hass=hass, api_key=entry.data[CONF_API_KEY])
+    hub = ImmichHub(host=entry.data[CONF_HOST], api_key=entry.data[CONF_API_KEY])
 
     if not await hub.authenticate():
         raise InvalidAuth

--- a/custom_components/immich/__init__.py
+++ b/custom_components/immich/__init__.py
@@ -16,7 +16,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})
 
-    hub = ImmichHub(host=entry.data[CONF_HOST], api_key=entry.data[CONF_API_KEY])
+    hub = ImmichHub(host=entry.data[CONF_HOST], hass=hass, api_key=entry.data[CONF_API_KEY])
 
     if not await hub.authenticate():
         raise InvalidAuth

--- a/custom_components/immich/__init__.py
+++ b/custom_components/immich/__init__.py
@@ -16,7 +16,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})
 
-    hub = ImmichHub(host=entry.data[CONF_HOST], api_key=entry.data[CONF_API_KEY])
+    hub = ImmichHub(host=entry.data[CONF_HOST], hass=hass, config_entry=entry api_key=entry.data[CONF_API_KEY])
 
     if not await hub.authenticate():
         raise InvalidAuth

--- a/custom_components/immich/__init__.py
+++ b/custom_components/immich/__init__.py
@@ -16,7 +16,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})
 
-    hub = ImmichHub(host=entry.data[CONF_HOST], hass=hass, config_entry=entry api_key=entry.data[CONF_API_KEY])
+    hub = ImmichHub(host=entry.data[CONF_HOST], hass=hass, config_entry=entry, api_key=entry.data[CONF_API_KEY])
 
     if not await hub.authenticate():
         raise InvalidAuth

--- a/custom_components/immich/config_flow.py
+++ b/custom_components/immich/config_flow.py
@@ -47,7 +47,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     url = url_normalize(data[CONF_HOST])
     api_key = data[CONF_API_KEY]
 
-    hub = ImmichHub(host=url, api_key=api_key)
+    hub = ImmichHub(host=url, hass=hass, api_key=api_key)
 
     if not await hub.authenticate():
         raise InvalidAuth

--- a/custom_components/immich/config_flow.py
+++ b/custom_components/immich/config_flow.py
@@ -28,6 +28,8 @@ from .const import (
     CROP_MODES,
     IMAGE_SELECTION_MODES,
     UPDATE_INTERVAL_UNITS,
+    CONF_CACHE_MODE,
+    DEFAULT_CACHE_MODE,
 )
 from .hub import CannotConnect, ImmichHub, InvalidAuth
 
@@ -129,6 +131,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         current_update_interval = self.config_entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
         current_update_interval_unit = self.config_entry.options.get(CONF_UPDATE_INTERVAL_UNIT, DEFAULT_UPDATE_INTERVAL_UNIT)
 
+        current_cache_mode = self.config_entry.options.get(CONF_CACHE_MODE, DEFAULT_CACHE_MODE)
+
         options_schema = vol.Schema(
             {
                 vol.Required(CONF_CROP_MODE, default=current_crop_mode): vol.In(CROP_MODES),
@@ -136,6 +140,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Required(CONF_UPDATE_INTERVAL, default=current_update_interval): vol.Coerce(int),
                 vol.Required(CONF_UPDATE_INTERVAL_UNIT, default=current_update_interval_unit): vol.In(UPDATE_INTERVAL_UNITS),
                 vol.Required(CONF_WATCHED_ALBUMS, default=current_albums_value): cv.multi_select(album_map),
+                vol.Required(CONF_CACHE_MODE, default=current_cache_mode): bool,
             }
         )
 

--- a/custom_components/immich/config_flow.py
+++ b/custom_components/immich/config_flow.py
@@ -47,7 +47,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     url = url_normalize(data[CONF_HOST])
     api_key = data[CONF_API_KEY]
 
-    hub = ImmichHub(host=url, hass=hass, api_key=api_key)
+    hub = ImmichHub(host=url, api_key=api_key)
 
     if not await hub.authenticate():
         raise InvalidAuth

--- a/custom_components/immich/config_flow.py
+++ b/custom_components/immich/config_flow.py
@@ -30,6 +30,9 @@ from .const import (
     UPDATE_INTERVAL_UNITS,
     CONF_CACHE_MODE,
     DEFAULT_CACHE_MODE,
+    CONF_PICTURE_TYPE,
+    DEFAULT_PICTURE_TYPE,
+    PICTURE_TYPES
 )
 from .hub import CannotConnect, ImmichHub, InvalidAuth
 
@@ -47,7 +50,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
     url = url_normalize(data[CONF_HOST])
     api_key = data[CONF_API_KEY]
 
-    hub = ImmichHub(host=url, api_key=api_key)
+    hub = ImmichHub(host=url, api_key=api_key, hass=hass, config_entry=None)
 
     if not await hub.authenticate():
         raise InvalidAuth
@@ -112,7 +115,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
         url = url_normalize(self.config_entry.data[CONF_HOST])
         api_key = self.config_entry.data[CONF_API_KEY]
-        hub = ImmichHub(host=url, api_key=api_key)
+        hub = ImmichHub(host=url, api_key=api_key, hass=None, config_entry=self.config_entry)
 
         if not await hub.authenticate():
             raise InvalidAuth
@@ -132,6 +135,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         current_update_interval_unit = self.config_entry.options.get(CONF_UPDATE_INTERVAL_UNIT, DEFAULT_UPDATE_INTERVAL_UNIT)
 
         current_cache_mode = self.config_entry.options.get(CONF_CACHE_MODE, DEFAULT_CACHE_MODE)
+        current_picture_type = self.config_entry.options.get(CONF_PICTURE_TYPE, DEFAULT_PICTURE_TYPE)
 
         options_schema = vol.Schema(
             {
@@ -140,6 +144,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Required(CONF_UPDATE_INTERVAL, default=current_update_interval): vol.Coerce(int),
                 vol.Required(CONF_UPDATE_INTERVAL_UNIT, default=current_update_interval_unit): vol.In(UPDATE_INTERVAL_UNITS),
                 vol.Required(CONF_WATCHED_ALBUMS, default=current_albums_value): cv.multi_select(album_map),
+                vol.Required(CONF_PICTURE_TYPE, default=current_picture_type): vol.In(PICTURE_TYPES),
                 vol.Required(CONF_CACHE_MODE, default=current_cache_mode): bool,
             }
         )

--- a/custom_components/immich/const.py
+++ b/custom_components/immich/const.py
@@ -22,5 +22,8 @@ DEFAULT_UPDATE_INTERVAL = 60  # in seconds
 DEFAULT_UPDATE_INTERVAL_UNIT = "seconds"
 UPDATE_INTERVAL_UNITS = ["seconds", "minutes"]
 
+CONF_CACHE_MODE = "cache_mode"
+DEFAULT_CACHE_MODE = False
+
 # Validation for update interval (min=1 second, max=24 hours)
 UPDATE_INTERVAL_VALIDATOR = vol.All(vol.Coerce(int), vol.Range(min=1, max=86400))

--- a/custom_components/immich/const.py
+++ b/custom_components/immich/const.py
@@ -25,9 +25,9 @@ UPDATE_INTERVAL_UNITS = ["seconds", "minutes"]
 CONF_CACHE_MODE = "cache_mode"
 DEFAULT_CACHE_MODE = False
 
-PICTURE_TYPES = ["original", "thumbnail"]
+PICTURE_TYPES = ["preview", "fullsize"]
 CONF_PICTURE_TYPE = "picture_type"
-DEFAULT_PICTURE_TYPE = "thumbnail"
+DEFAULT_PICTURE_TYPE = "preview"
 
 # Validation for update interval (min=1 second, max=24 hours)
 UPDATE_INTERVAL_VALIDATOR = vol.All(vol.Coerce(int), vol.Range(min=1, max=86400))

--- a/custom_components/immich/const.py
+++ b/custom_components/immich/const.py
@@ -25,5 +25,9 @@ UPDATE_INTERVAL_UNITS = ["seconds", "minutes"]
 CONF_CACHE_MODE = "cache_mode"
 DEFAULT_CACHE_MODE = False
 
+PICTURE_TYPES = ["original", "thumbnail"]
+CONF_PICTURE_TYPE = "picture_type"
+DEFAULT_PICTURE_TYPE = "thumbnail"
+
 # Validation for update interval (min=1 second, max=24 hours)
 UPDATE_INTERVAL_VALIDATOR = vol.All(vol.Coerce(int), vol.Range(min=1, max=86400))

--- a/custom_components/immich/hub.py
+++ b/custom_components/immich/hub.py
@@ -135,10 +135,10 @@ class ImmichHub:
 
         if self.cache_assets:
             for asset_id in album_assets:
-                asset_bytes = await self.download_asset(asset_id)
-                if asset_bytes:
-                    filename = os.path.join(self.asset_cache_path, f"{asset_id}")  # Optional: content_type prüfen
-                    if not os.path.isfile(filename):
+                filename = os.path.join(self.asset_cache_path, f"{asset_id}")  # Optional: content_type prüfen
+                if not os.path.isfile(filename):
+                    asset_bytes = await self.download_asset(asset_id)
+                    if asset_bytes:
                         async with aiofiles.open(filename, "wb") as f:
                             await f.write(asset_bytes)
 

--- a/custom_components/immich/hub.py
+++ b/custom_components/immich/hub.py
@@ -117,7 +117,7 @@ class ImmichHub:
     async def cache_album_assets(self, album_assets: list[str]) -> bool:
         """Cache album assets."""
 
-        base_path = os.path.join(self.hass.config.path, "immich_cache")
+        base_path = os.path.join(self.hass.config.path('immich_cache'), "immich_cache")
         os.makedirs(base_path, exist_ok=True)
 
         for asset_id in album_assets:

--- a/custom_components/immich/hub.py
+++ b/custom_components/immich/hub.py
@@ -161,11 +161,12 @@ class ImmichHub:
         self.cache_assets = self.config_entry.options.get(CONF_CACHE_MODE, DEFAULT_CACHE_MODE)
         self.asset_cache_path = self.hass.config.path('immich_cache')
         
-        try:
-            shutil.rmtree(self.asset_cache_path)
-            _LOGGER.info("Cleared asset cache")
-        except Exception as e:
-            _LOGGER.error("Unable to clear asset cache directory: %s", e)
+        if os.path.isdir(self.asset_cache_path):
+            try:
+                shutil.rmtree(self.asset_cache_path)
+                _LOGGER.info("Cleared asset cache")
+            except Exception as e:
+                _LOGGER.error("Unable to clear asset cache directory: %s", e)
 
         if self.cache_assets:
             try:

--- a/custom_components/immich/hub.py
+++ b/custom_components/immich/hub.py
@@ -9,6 +9,7 @@ import aiofiles
 import os
 
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.core import HomeAssistant
 
 _HEADER_API_KEY = "x-api-key"
 _LOGGER = logging.getLogger(__name__)
@@ -19,10 +20,11 @@ _ALLOWED_MIME_TYPES = ["image/png", "image/jpeg"]
 class ImmichHub:
     """Immich API hub."""
 
-    def __init__(self, host: str, api_key: str) -> None:
+    def __init__(self, hass: HomeAssistant, host: str, api_key: str) -> None:
         """Initialize."""
         self.host = host
         self.api_key = api_key
+        self.hass = hass
 
     async def authenticate(self) -> bool:
         """Test if we can authenticate with the host."""

--- a/custom_components/immich/hub.py
+++ b/custom_components/immich/hub.py
@@ -20,11 +20,10 @@ _ALLOWED_MIME_TYPES = ["image/png", "image/jpeg"]
 class ImmichHub:
     """Immich API hub."""
 
-    def __init__(self, hass: HomeAssistant, host: str, api_key: str) -> None:
+    def __init__(self, host: str, api_key: str) -> None:
         """Initialize."""
         self.host = host
         self.api_key = api_key
-        self.hass = hass
 
     async def authenticate(self) -> bool:
         """Test if we can authenticate with the host."""
@@ -114,10 +113,10 @@ class ImmichHub:
             _LOGGER.error("Error connecting to the API: %s", exception)
             raise CannotConnect from exception
 
-    async def cache_album_assets(self, album_assets: list[str]) -> bool:
+    async def cache_album_assets(self, hass, album_assets: list[str]) -> bool:
         """Cache album assets."""
 
-        base_path = os.path.join(self.hass.config.path('immich_cache'), "immich_cache")
+        base_path = os.path.join(hass.config.path('immich_cache'), "immich_cache")
         os.makedirs(base_path, exist_ok=True)
 
         for asset_id in album_assets:

--- a/custom_components/immich/hub.py
+++ b/custom_components/immich/hub.py
@@ -110,11 +110,7 @@ class ImmichHub:
 
         try:
             async with aiohttp.ClientSession() as session:
-                if picture_type == "thumbnail":
-                    url = urljoin(self.host, f"/api/assets/{asset_id}/thumbnail?size=preview")
-                if picture_type == "original":
-                    url = urljoin(self.host, f"/api/assets/{asset_id}/original")
-                    
+                url = urljoin(self.host, f"/api/assets/{asset_id}/thumbnail?size={picture_type}")    
                 headers = {_HEADER_API_KEY: self.api_key}
 
                 async with session.get(url=url, headers=headers) as response:

--- a/custom_components/immich/hub.py
+++ b/custom_components/immich/hub.py
@@ -167,12 +167,12 @@ class ImmichHub:
         except Exception as e:
             _LOGGER.error("Unable to clear asset cache directory: %s", e)
 
-            if self.cache_assets:
-                try:
-                    os.makedirs(self.asset_cache_path, exist_ok=True)
-                    _LOGGER.info("Created asset cache directory: ", self.asset_cache_path)
-                except Exception as e:
-                    _LOGGER.error("Unable to create asset cache directory: %s %s", self.asset_cache_path, e)
+        if self.cache_assets:
+            try:
+                os.makedirs(self.asset_cache_path, exist_ok=True)
+                _LOGGER.info("Created asset cache directory: ", self.asset_cache_path)
+            except Exception as e:
+                _LOGGER.error("Unable to create asset cache directory: %s %s", self.asset_cache_path, e)
 
     async def list_favorite_images(self) -> list[dict]:
         """List all favorite images."""

--- a/custom_components/immich/hub.py
+++ b/custom_components/immich/hub.py
@@ -142,7 +142,7 @@ class ImmichHub:
                         async with aiofiles.open(filename, "wb") as f:
                             await f.write(asset_bytes)
 
-    async def initialize_asset_cache(self, hass, config_entry) -> bool:
+    def initialize_asset_cache(self, hass, config_entry) -> bool:
         self.cache_assets = config_entry.options.get(CONF_CACHE_MODE, DEFAULT_CACHE_MODE)
         self.asset_cache_path = hass.config.path('immich_cache')
         

--- a/custom_components/immich/hub.py
+++ b/custom_components/immich/hub.py
@@ -5,6 +5,8 @@ import logging
 from urllib.parse import urljoin
 
 import aiohttp
+import aiofiles
+import os
 
 from homeassistant.exceptions import HomeAssistantError
 
@@ -109,6 +111,19 @@ class ImmichHub:
         except aiohttp.ClientError as exception:
             _LOGGER.error("Error connecting to the API: %s", exception)
             raise CannotConnect from exception
+
+    async def cache_album_assets(self, album_assets: list[str]) -> bool:
+        """Cache album assets."""
+
+        base_path = os.path.join(self.hass.config.path, "immich_cache")
+        os.makedirs(base_path, exist_ok=True)
+
+        for asset_id in album_assets:
+            asset_bytes = await self.download_asset(asset_id)
+            if asset_bytes:
+                filename = os.path.join(base_path, f"{asset_id}.jpg")  # Optional: content_type prüfen
+                async with aiofiles.open(filename, "wb") as f:
+                    await f.write(asset_bytes)
 
     async def list_favorite_images(self) -> list[dict]:
         """List all favorite images."""

--- a/custom_components/immich/image.py
+++ b/custom_components/immich/image.py
@@ -204,7 +204,7 @@ class ImmichImageAlbum(BaseImmichImage):
         self._album_id = album_id
         self._attr_unique_id = f"{config_entry.entry_id}_{album_id}"
         self._attr_name = f"Immich: {album_name}"
-        hub.initialize_asset_cache(hass=self.hass, config_entry=self.config_entry)
+        self.hub.initialize_asset_cache(hass=self.hass, config_entry=self.config_entry)
 
     async def _refresh_available_asset_ids(self) -> list[str] | None:
         """Refresh the list of available asset IDs."""

--- a/custom_components/immich/image.py
+++ b/custom_components/immich/image.py
@@ -30,7 +30,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up Immich image platform."""
     hub = ImmichHub(
-        host=config_entry.data[CONF_HOST], api_key=config_entry.data[CONF_API_KEY]
+        host=config_entry.data[CONF_HOST], hass=hass, config_entry=config_entry, api_key=config_entry.data[CONF_API_KEY]
     )
 
     update_interval = config_entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)

--- a/custom_components/immich/image.py
+++ b/custom_components/immich/image.py
@@ -204,7 +204,7 @@ class ImmichImageAlbum(BaseImmichImage):
         self._album_id = album_id
         self._attr_unique_id = f"{config_entry.entry_id}_{album_id}"
         self._attr_name = f"Immich: {album_name}"
-        self.hub.initialize_asset_cache(hass=self.hass, config_entry=self.config_entry)
+        self.hub.initialize_asset_cache()
 
     async def _refresh_available_asset_ids(self) -> list[str] | None:
         """Refresh the list of available asset IDs."""

--- a/custom_components/immich/image.py
+++ b/custom_components/immich/image.py
@@ -30,7 +30,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up Immich image platform."""
     hub = ImmichHub(
-        host=config_entry.data[CONF_HOST], hass=hass, api_key=config_entry.data[CONF_API_KEY]
+        host=config_entry.data[CONF_HOST], api_key=config_entry.data[CONF_API_KEY]
     )
 
     update_interval = config_entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
@@ -210,6 +210,6 @@ class ImmichImageAlbum(BaseImmichImage):
         album_assets = [image["id"] for image in await self.hub.list_album_images(self._album_id)]
 
         if self.config_entry.options.get(CONF_CACHE_MODE, DEFAULT_CACHE_MODE):
-            await self.hub.cache_album_assets(album_assets)
+            await self.hub.cache_album_assets(album_assets=album_assets, hass=self.hass)
         
         return album_assets #[image["id"] for image in await self.hub.list_album_images(self._album_id)]

--- a/custom_components/immich/image.py
+++ b/custom_components/immich/image.py
@@ -30,7 +30,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up Immich image platform."""
     hub = ImmichHub(
-        host=config_entry.data[CONF_HOST], api_key=config_entry.data[CONF_API_KEY]
+        host=config_entry.data[CONF_HOST], hass=hass, api_key=config_entry.data[CONF_API_KEY]
     )
 
     update_interval = config_entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)

--- a/custom_components/immich/image.py
+++ b/custom_components/immich/image.py
@@ -15,7 +15,8 @@ from .const import (
     CONF_WATCHED_ALBUMS, DOMAIN, CONF_CROP_MODE, CONF_IMAGE_SELECTION_MODE,
     CONF_UPDATE_INTERVAL, CONF_UPDATE_INTERVAL_UNIT,
     DEFAULT_CROP_MODE, DEFAULT_IMAGE_SELECTION_MODE,
-    DEFAULT_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL_UNIT
+    DEFAULT_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL_UNIT,
+    CONF_CACHE_MODE, DEFAULT_CACHE_MODE
 )
 from .hub import ImmichHub
 from .coordinator import process_images_for_slideshow
@@ -206,4 +207,9 @@ class ImmichImageAlbum(BaseImmichImage):
 
     async def _refresh_available_asset_ids(self) -> list[str] | None:
         """Refresh the list of available asset IDs."""
-        return [image["id"] for image in await self.hub.list_album_images(self._album_id)]
+        album_assets = [image["id"] for image in await self.hub.list_album_images(self._album_id)]
+
+        if self.config_entry.options.get(CONF_CACHE_MODE, DEFAULT_CACHE_MODE):
+            await self.hub.cache_album_assets(album_assets)
+        
+        return album_assets #[image["id"] for image in await self.hub.list_album_images(self._album_id)]

--- a/custom_components/immich/image.py
+++ b/custom_components/immich/image.py
@@ -204,12 +204,11 @@ class ImmichImageAlbum(BaseImmichImage):
         self._album_id = album_id
         self._attr_unique_id = f"{config_entry.entry_id}_{album_id}"
         self._attr_name = f"Immich: {album_name}"
+        hub.initialize_asset_cache(hass=self.hass, config_entry=self.config_entry)
 
     async def _refresh_available_asset_ids(self) -> list[str] | None:
         """Refresh the list of available asset IDs."""
         album_assets = [image["id"] for image in await self.hub.list_album_images(self._album_id)]
-
-        if self.config_entry.options.get(CONF_CACHE_MODE, DEFAULT_CACHE_MODE):
-            await self.hub.cache_album_assets(album_assets=album_assets, hass=self.hass)
+        await self.hub.cache_album_assets(album_assets=album_assets)
         
         return album_assets #[image["id"] for image in await self.hub.list_album_images(self._album_id)]

--- a/custom_components/immich/strings.json
+++ b/custom_components/immich/strings.json
@@ -22,7 +22,8 @@
       "init": {
         "data": {
           "watched_albums": "Albums for which entities will be created",
-          "cache_mode": "Cache assets locally"
+          "cache_mode": "Cache assets locally",
+          "picture_type": "The picture type to load"
         }
       }
     }

--- a/custom_components/immich/strings.json
+++ b/custom_components/immich/strings.json
@@ -21,7 +21,8 @@
     "step": {
       "init": {
         "data": {
-          "watched_albums": "Albums for which entities will be created"
+          "watched_albums": "Albums for which entities will be created",
+          "cache_mode": "Cache assets locally"
         }
       }
     }

--- a/custom_components/immich/translations/en.json
+++ b/custom_components/immich/translations/en.json
@@ -21,7 +21,8 @@
         "step": {
             "init": {
                 "data": {
-                    "watched_albums": "Albums for which entities will be created"
+                    "watched_albums": "Albums for which entities will be created",
+                    "cache_mode": "Cache assets locally"
                 }
             }
         }

--- a/custom_components/immich/translations/en.json
+++ b/custom_components/immich/translations/en.json
@@ -22,7 +22,8 @@
             "init": {
                 "data": {
                     "watched_albums": "Albums for which entities will be created",
-                    "cache_mode": "Cache assets locally"
+                    "cache_mode": "Cache assets locally",
+                    "picture_type": "The picture type to load"
                 }
             }
         }


### PR DESCRIPTION
1. In an effort to reduce NAS disk usage from this integration and allow disks to spin down, I've implemented a caching mechanism for assets. If `Cache assets locally` is turned on, then the integration will download all allowed MIME types (jpg/png) to `config/immich_cache`. A request to download an asset will be served from cache instead and only be downloaded directly, if no cached copy can be found. The cache is cleared and re-created when HA starts. During the regular asset update cycle, all missing assets will be fetched from Immich, while assets that are already cached will be retained and not be downloaded again until the cache is re-created.
EDIT: Caching only applies to Album entites.

3. I've made the thumbnail-quality configurable. Default remains `preview`, but can be changed to `fullsize` to get the original size and quality of the picture via `/api/assets/{asset_id}/thumbnail?size={picture_type}`

![grafik](https://github.com/user-attachments/assets/b1dcb47b-470c-4e4f-8db5-c0383f939e4c)
